### PR TITLE
Merge devops_zipper into develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 # production
 /build
 
+# zipping
+/target
+
 # misc
 .DS_Store
 .env.local

--- a/package.json
+++ b/package.json
@@ -76,6 +76,8 @@
   "scripts": {
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",
+    "zip": "7z a -t7z -mx9 -r target/build.7z build/*",
+    "buildz": "npm run build && npm run zip",
     "test": "node scripts/test.js"
   },
   "eslintConfig": {


### PR DESCRIPTION
- `npm run zip` creates a build.7z inside 'target' (new folder, created when running the script) of files inside 'build' folder
  - 7zip is now a dependency
  - Flags used:
    -  -t7z: compression **t**ype 7zip
    -  -mx9: compression algorithm 9 (Ultra)
    -  -r: add files **r**ecursively
- `npm run buildz` runs `npm run build` and then `npm run zip`
- Updated .gitignore to not track the new 'target' folder

@iskewedI 